### PR TITLE
add lazy to supervisor variables

### DIFF
--- a/cookbooks/supervisor/recipes/default.rb
+++ b/cookbooks/supervisor/recipes/default.rb
@@ -42,16 +42,16 @@ template node['supervisor']['conffile'] do
   group 'root'
   mode '644'
   variables(lazy do
-      	{
-	    inet_port: node['supervisor']['inet_port'],
-            inet_username: node['supervisor']['inet_username'],
-            inet_password: node['supervisor']['inet_password'],
-            supervisord_minfds: node['supervisor']['minfds'],
-            supervisord_minprocs: node['supervisor']['minprocs'],
-            supervisor_version: node['supervisor']['version'],
-            socket_file: node['supervisor']['socket_file']
-	}
-     end)
+    {
+      inet_port: node['supervisor']['inet_port'],
+      inet_username: node['supervisor']['inet_username'],
+      inet_password: node['supervisor']['inet_password'],
+      supervisord_minfds: node['supervisor']['minfds'],
+      supervisord_minprocs: node['supervisor']['minprocs'],
+      supervisor_version: node['supervisor']['version'],
+      socket_file: node['supervisor']['socket_file']
+	  }
+  end)
 end
 
 directory node['supervisor']['log_dir'] do

--- a/cookbooks/supervisor/recipes/default.rb
+++ b/cookbooks/supervisor/recipes/default.rb
@@ -41,13 +41,17 @@ template node['supervisor']['conffile'] do
   owner 'root'
   group 'root'
   mode '644'
-  variables(inet_port: node['supervisor']['inet_port'],
+  variables(lazy do
+      	{
+	    inet_port: node['supervisor']['inet_port'],
             inet_username: node['supervisor']['inet_username'],
             inet_password: node['supervisor']['inet_password'],
             supervisord_minfds: node['supervisor']['minfds'],
             supervisord_minprocs: node['supervisor']['minprocs'],
             supervisor_version: node['supervisor']['version'],
-            socket_file: node['supervisor']['socket_file'])
+            socket_file: node['supervisor']['socket_file']
+	}
+     end)
 end
 
 directory node['supervisor']['log_dir'] do


### PR DESCRIPTION
In order to set credentials in execution phase of a Chef Infra Client, the template variable need to be lazy loaded.